### PR TITLE
Align data exports with source notebooks

### DIFF
--- a/processes/fractional_cover.py
+++ b/processes/fractional_cover.py
@@ -167,13 +167,9 @@ class FractionalCover(CubeQueryTask):
         ## Write file
 
         file_name = path.join(path_prefix, "fractional_cover.tiff")
-        ds = xr.DataArray.to_dataset(
-            fractional_cover_output, dim=None, name="fractional_cover"
-        )
         import_export.export_xarray_to_geotiff(
-            ds,
+            fractional_cover_output,
             file_name,
-            bands=["fractional_cover"],
             crs=output_projection,
             x_coord="longitude",
             y_coord="latitude",

--- a/processes/land_change.py
+++ b/processes/land_change.py
@@ -247,13 +247,9 @@ class LandChange(CubeQueryTask):
         result = []
 
         file_name = path.join(path_prefix, "land_change.tiff")
-        ds = xr.DataArray.to_dataset(
-            parameter_anomaly_output, dim=None, name="land_change"
-        )
         import_export.export_xarray_to_geotiff(
-            ds,
+            parameter_anomaly_output,
             file_name,
-            bands=["land_change"],
             crs=output_projection,
             x_coord="longitude",
             y_coord="latitude",
@@ -261,11 +257,9 @@ class LandChange(CubeQueryTask):
         result.append(file_name)
 
         file_name = path.join(path_prefix, "bs_change.tiff")
-        ds = xr.DataArray.to_dataset(bs_output, dim=None, name="bs_change")
         import_export.export_xarray_to_geotiff(
-            ds,
+            bs_output,
             file_name,
-            bands=["bs_change"],
             crs=output_projection,
             x_coord="longitude",
             y_coord="latitude",
@@ -273,11 +267,9 @@ class LandChange(CubeQueryTask):
         result.append(file_name)
 
         file_name = path.join(path_prefix, "pv_change.tiff")
-        ds = xr.DataArray.to_dataset(pv_output, dim=None, name="bs_change")
         import_export.export_xarray_to_geotiff(
-            ds,
+            pv_output,
             file_name,
-            bands=["pv_change"],
             crs=output_projection,
             x_coord="longitude",
             y_coord="latitude",
@@ -285,11 +277,9 @@ class LandChange(CubeQueryTask):
         result.append(file_name)
 
         file_name = path.join(path_prefix, "npv_change.tiff")
-        ds = xr.DataArray.to_dataset(npv_output, dim=None, name="npv_change")
         import_export.export_xarray_to_geotiff(
-            ds,
+            npv_output,
             file_name,
-            bands=["npv_change"],
             crs=output_projection,
             x_coord="longitude",
             y_coord="latitude",

--- a/processes/vegetation_change.py
+++ b/processes/vegetation_change.py
@@ -315,13 +315,9 @@ class VegetationChange(CubeQueryTask):
         result = []
 
         file_name = path.join(path_prefix, "veg_change.tiff")
-        ds = xr.DataArray.to_dataset(
-            parameter_anomaly_output, dim=None, name="land_change"
-        )
         import_export.export_xarray_to_geotiff(
-            ds,
+            parameter_anomaly_output,
             file_name,
-            bands=["veg_change"],
             crs=output_projection,
             x_coord="longitude",
             y_coord="latitude",
@@ -329,9 +325,8 @@ class VegetationChange(CubeQueryTask):
         result.append(file_name)
 
         file_name = path.join(path_prefix, "param_thres.tiff")
-        ds = xr.DataArray.to_dataset(param_thres_output, dim=None, name="param_thres")
         import_export.export_xarray_to_geotiff(
-            ds,
+            param_thres_output,
             file_name,
             bands=["param_thres"],
             crs=output_projection,

--- a/processes/water_change.py
+++ b/processes/water_change.py
@@ -1,5 +1,4 @@
 import numpy as np
-import xarray as xr
 import dask
 from os import path
 
@@ -104,12 +103,16 @@ class WaterChange(CubeQueryTask):
         query = create_base_query(aoi, res, output_projection, aoi_crs, dask_chunks)
 
         all_measurements = ["green", "red", "blue", "nir", "swir1", "swir2"]
-        _baseline_product, _baseline_measurement, baseline_water_product = create_product_measurement(
-            platform_base, all_measurements
-        )
-        _analysis_product, _analysis_measurement, analysis_water_product = create_product_measurement(
-            platform_analysis, all_measurements
-        )
+        (
+            _baseline_product,
+            _baseline_measurement,
+            baseline_water_product,
+        ) = create_product_measurement(platform_base, all_measurements)
+        (
+            _analysis_product,
+            _analysis_measurement,
+            analysis_water_product,
+        ) = create_product_measurement(platform_analysis, all_measurements)
 
         baseline_time_period = (baseline_start_date, baseline_end_date)
         analysis_time_period = (analysis_start_date, analysis_end_date)
@@ -183,13 +186,9 @@ class WaterChange(CubeQueryTask):
         result = []
 
         file_name = path.join(path_prefix, "difference_range.tiff")
-        ds = xr.DataArray.to_dataset(
-            difference_range_output, dim=None, name="difference_range"
-        )
         import_export.export_xarray_to_geotiff(
-            ds,
+            difference_range_output,
             file_name,
-            bands=["difference_range"],
             crs=output_projection,
             x_coord="x",
             y_coord="y",
@@ -197,11 +196,9 @@ class WaterChange(CubeQueryTask):
         result.append(file_name)
 
         file_name = path.join(path_prefix, "difference.tiff")
-        ds = xr.DataArray.to_dataset(difference_output, dim=None, name="difference")
         import_export.export_xarray_to_geotiff(
-            ds,
+            difference_output,
             file_name,
-            bands=["difference"],
             crs=output_projection,
             x_coord="x",
             y_coord="y",

--- a/processes/water_permanency.py
+++ b/processes/water_permanency.py
@@ -1,4 +1,3 @@
-import xarray as xr
 from os import path
 
 from cubequery.tasks import CubeQueryTask, Parameter, DType
@@ -102,11 +101,8 @@ class WaterPermanency(CubeQueryTask):
         ## Write files
 
         file_name = path.join(path_prefix, "water.tiff")
-        ds = xr.DataArray.to_dataset(
-            water_composite_mean_output, dim=None, name="water"
-        )
         import_export.export_xarray_to_geotiff(
-            ds,
+            water_composite_mean_output,
             file_name,
             bands=["water"],
             crs=output_projection,

--- a/processes/water_quality.py
+++ b/processes/water_quality.py
@@ -139,38 +139,20 @@ class WaterQuality(CubeQueryTask):
         result = []
 
         file_name = path.join(path_prefix, "mean_tsm.tiff")
-        ds = xr.DataArray.to_dataset(mean_tsm, dim=None, name="mean_tsm")
         import_export.export_xarray_to_geotiff(
-            ds,
-            file_name,
-            bands=["mean_tsm"],
-            crs=output_projection,
-            x_coord="x",
-            y_coord="y",
+            mean_tsm, file_name, crs=output_projection, x_coord="x", y_coord="y",
         )
         result.append(file_name)
 
         file_name = path.join(path_prefix, "min_tsm.tiff")
-        ds = xr.DataArray.to_dataset(min_tsm, dim=None, name="min_tsm")
         import_export.export_xarray_to_geotiff(
-            ds,
-            file_name,
-            bands=["min_tsm"],
-            crs=output_projection,
-            x_coord="x",
-            y_coord="y",
+            min_tsm, file_name, crs=output_projection, x_coord="x", y_coord="y",
         )
         result.append(file_name)
 
         file_name = path.join(path_prefix, "max_tsm.tiff")
-        ds = xr.DataArray.to_dataset(max_tsm, dim=None, name="max_tsm")
         import_export.export_xarray_to_geotiff(
-            ds,
-            file_name,
-            bands=["max_tsm"],
-            crs=output_projection,
-            x_coord="x",
-            y_coord="y",
+            max_tsm, file_name, crs=output_projection, x_coord="x", y_coord="y",
         )
         result.append(file_name)
 


### PR DESCRIPTION
Change geotiff creation so it aligns properly with the data exports from
the original notebooks.

Most of the data we're exporting is already a DataSet so we don't want
to try to convert it to one. Most of the time when the data is a
DataArray we're happy letting `export_xarray_to_geotiff` convert the
DataArray directly to a geotiff without first converting it to a DataSet
ourselves.

@emilyselwood 